### PR TITLE
Remove Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Compile
+      run: rebar3 compile
     - name: Run tests
-      run: make test
+      run: rebar3 do ct, eunit
     - name: Run dialyzer
       run: rebar3 dialyzer

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-all:
-
-.PHONY: test
-
-test:
-	rebar3 as test do compile, ct, eunit


### PR DESCRIPTION
Generate compiled file to test is no longer required, and that was the purpose of the Makefile. So, removing it is fine.