### PR TITLE
Adds the possibility to define eunit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Finished in 0.013 seconds
 Options can be provided when using the `doctest:module/2` function. The available options are:
 - `moduledoc` :: `boolean()`: enable or disable `-moduledoc` test
 - `funs` :: `boolean()` | `[{atom(), arity()}]`: enable or disable `-doc` tests or define the functions to be tested
+- `eunit` :: `default | term()`: set eunit options
 
 ### Testing via doctest header
 
@@ -135,24 +136,29 @@ Finished in 0.010 seconds
 #### Options
 
 Options are defined via the `-doctest` attribute and can be defined multiple times. The available options are:
-- `boolean()` | `{enabled, boolean()}`: enable or disable the test running, e.g:
+- `boolean()` | `{enabled, boolean()}`: enable or disable the test running, e.g.:
   ```erlang
   -doctest true.
   ```
-- `{moduledoc, boolean()}`: enable or disable `-moduledoc` test, e.g:
+- `{moduledoc, boolean()}`: enable or disable `-moduledoc` test, e.g.:
   ```erlang
   -doctest {moduledoc, true}.
   ```
-- `[{atom(), arity()}]` | `{funs, [{atom(), arity()}] | boolean()}`: enable or disable `-doc` tests or define the functions to be tested, e.g:
+- `[{atom(), arity()}]` | `{funs, [{atom(), arity()}] | boolean()}`: enable or disable `-doc` tests or define the functions to be tested, e.g.:
   ```erlang
   -doctest [add/2].
   ```
-- `map()`: define all or partial options, e.g:
+- `eunit` :: `default | term()`: set eunit options, e.g.:
+  ```erlang
+  -doctest {eunit, default}.
+  ```
+- `map()`: define all or partial options, e.g.:
   ```erlang
   -doctest #{
       enabled => true,
       moduledoc => true,
-      funs => [add/2]
+      funs => [add/2],
+      eunit => default
   }.
   ```
 

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,8 @@
     %     Line 49 Column 17: Unknown function rebar_state:command_parsed_args/1
     %     Line 50 Column 17: Unknown function rebar_state:get/3
     %
-    {warnings, [no_unknown]}
+    {warnings, [no_unknown]},
+    {plt_extra_apps, [syntax_tools, compiler, eunit]}
  ]}.
 
 {deps, []}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,18 @@
 
 {erl_opts, [debug_info]}.
 
+{dialyzer, [
+    % Fixes a bug on 'doctest_eunit':
+    %
+    %     $ rebar3 dialyzer
+    %     src/doctest_eunit.erl
+    %     Line 36 Column 32: Unknown function rebar3:init_config/0
+    %     Line 49 Column 17: Unknown function rebar_state:command_parsed_args/1
+    %     Line 50 Column 17: Unknown function rebar_state:get/3
+    %
+    {warnings, [no_unknown]}
+ ]}.
+
 {deps, []}.
 
 {project_plugins, [rebar3_hex, rebar3_ex_doc]}.

--- a/src/doctest.app.src
+++ b/src/doctest.app.src
@@ -2,7 +2,7 @@
     {description, "A library to test Erlang doc attributes"},
     {vsn, "0.5.1"},
     {registered, []},
-    {applications, [kernel, stdlib, syntax_tools, compiler, eunit]},
+    {applications, [kernel, stdlib]},
     {env, []},
     {modules, []},
     {licenses, ["Apache-2.0"]},

--- a/src/doctest.erl
+++ b/src/doctest.erl
@@ -29,7 +29,6 @@ Provides `module/1` and `module/2` to test doc attributes.
         , parse_fun/3
         , parse/4
         , should_test_function/2
-        , run/1
         ]).
 
 % Check OTP version >= 27.
@@ -64,7 +63,7 @@ module(Mod, Opts) when is_atom(Mod), is_map(Opts) ->
                     []
             end,
             FunsTests = doc_tests(Mod, Docs, maps:get(funs, Opts, true)),
-            run(ModTests ++ FunsTests);
+            doctest_eunit:test(ModTests ++ FunsTests);
         {error, Reason} ->
             {error, Reason}
     end.
@@ -124,9 +123,6 @@ should_test_function(false, _Fun) ->
     false;
 should_test_function(Funs, Fun) when is_list(Funs) ->
     lists:member(Fun, Funs).
-
-run(Tests) ->
-    eunit:test(Tests, [no_tty, {report, {eunit_progress, [colored]}}]).
 
 %%%=====================================================================
 %%% Internal functions

--- a/src/doctest.erl
+++ b/src/doctest.erl
@@ -37,7 +37,8 @@ Provides `module/1` and `module/2` to test doc attributes.
 
 -type options() :: #{
     moduledoc => boolean(),
-    funs => boolean() | [{atom(), arity()}]
+    funs => boolean() | [{atom(), arity()}],
+    eunit => default | term()
 }.
 -type test_result() :: ok | error | {error, term()}.
 
@@ -56,10 +57,12 @@ module(Mod) ->
 module(Mod, Opts) when is_atom(Mod), is_map(Opts) ->
     case code:get_doc(Mod) of
         {ok, #docs_v1{anno = Anno, module_doc = Lang, docs = Docs}} ->
-            doctest_eunit:test([
+            Tests = [
                 moduledoc_tests(Mod, Anno, Lang, Opts),
                 doc_tests(Mod, Docs, Opts)
-            ]);
+            ],
+            EunitOpts = maps:get(eunit, Opts, default),
+            doctest_eunit:test(Tests, EunitOpts);
         {error, Reason} ->
             {error, Reason}
     end.

--- a/src/doctest_eunit.erl
+++ b/src/doctest_eunit.erl
@@ -1,0 +1,91 @@
+%%%---------------------------------------------------------------------
+%%% Copyright 2024 William Fank Thomé
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%---------------------------------------------------------------------
+-module(doctest_eunit).
+-moduledoc false.
+
+% API functions
+-export([test/1]).
+
+%%%=====================================================================
+%%% API functions
+%%%=====================================================================
+
+test(Tests) ->
+    eunit:test(Tests, options()).
+
+%%%=====================================================================
+%%% Internal functions
+%%%=====================================================================
+
+options() ->
+    case erlang:module_loaded(rebar3) of
+        true ->
+            resolve_eunit_opts(rebar3:init_config());
+        false ->
+            []
+    end.
+
+%%%=====================================================================
+%%% rebar3 non-exported functions
+%%%=====================================================================
+
+% TODO: Maybe submit a PR exporting 'resolve_eunit_opts/1'.
+% @see https://github.com/erlang/rebar3/blob/b64d94f4e6fb738c4a3004faf833e0b9617d86a8/apps/rebar/src/rebar_prv_eunit.erl#L443
+
+resolve_eunit_opts(State) ->
+    {Opts, _} = rebar_state:command_parsed_args(State),
+    EUnitOpts = rebar_state:get(State, eunit_opts, []),
+    EUnitOpts1 = case proplists:get_value(verbose, Opts, false) of
+                    true  -> set_verbose(EUnitOpts);
+                    false -> EUnitOpts
+                 end,
+    EUnitOpts2 = case proplists:get_value(profile, Opts, false) of
+                    true  -> set_profile(EUnitOpts1);
+                    false -> EUnitOpts1
+                 end,
+    IsVerbose = lists:member(verbose, EUnitOpts2),
+    case proplists:get_value(eunit_formatters, Opts, not IsVerbose) of
+        true  -> custom_eunit_formatters(EUnitOpts2);
+        false -> EUnitOpts2
+    end.
+
+custom_eunit_formatters(Opts) ->
+    ReportOpts = custom_eunit_report_options(Opts),
+    %% If `report` is already set then treat that like `eunit_formatters` is false
+    case lists:keymember(report, 1, Opts) of
+        true -> Opts;
+        false -> [no_tty, {report, {eunit_progress, ReportOpts}} | Opts]
+    end.
+
+custom_eunit_report_options(Opts) ->
+    case lists:member(profile, Opts) of
+        true -> [colored, profile];
+        false -> [colored]
+    end.
+
+set_profile(Opts) ->
+    %% if `profile` is already set don't set it again
+    case lists:member(profile, Opts) of
+        true  -> Opts;
+        false -> [profile] ++ Opts
+    end.
+
+set_verbose(Opts) ->
+    %% if `verbose` is already set don't set it again
+    case lists:member(verbose, Opts) of
+        true  -> Opts;
+        false -> [verbose] ++ Opts
+    end.

--- a/src/doctest_eunit.erl
+++ b/src/doctest_eunit.erl
@@ -17,14 +17,19 @@
 -moduledoc false.
 
 % API functions
--export([test/1]).
+-export([test/1, test/2]).
 
 %%%=====================================================================
 %%% API functions
 %%%=====================================================================
 
 test(Tests) ->
-    eunit:test(Tests, options()).
+    test(Tests, default).
+
+test(Tests, default) ->
+    eunit:test(Tests, options());
+test(Tests, Options) ->
+    eunit:test(Tests, Options).
 
 %%%=====================================================================
 %%% Internal functions

--- a/src/doctest_parse_transform.erl
+++ b/src/doctest_parse_transform.erl
@@ -15,7 +15,7 @@
 %%%---------------------------------------------------------------------
 -module(doctest_parse_transform).
 -moduledoc """
-Generate tests for -doc attributes via parse transform.
+Generate tests for doc attributes via parse transform.
 
 Just plug the header on your module:
 ```
@@ -44,7 +44,7 @@ parse_transform(Forms, _Opt) ->
     File = file(Forms),
     DocTest = doctest(doctest_attrs(Forms), File),
     Docs = docs(DocTest, doc_attrs(Forms)),
-    doctest_eunit:test(tests(File, Forms, Docs), DocTest#doctest.eunit),
+    test(tests(File, Forms, Docs), DocTest),
     % Return the original forms
 	Forms.
 
@@ -52,13 +52,9 @@ parse_transform(Forms, _Opt) ->
 %%% Internal functions
 %%%=====================================================================
 
-docs(#doctest{moduledoc = ShouldTestModDoc, funs = Funs}, AllDocs) ->
-    lists:filter(fun
-        ({moduledoc, _Doc}) ->
-            ShouldTestModDoc;
-        ({{doc, {function, {F, A, _Ln}}}, _Doc}) ->
-            doctest:should_test_function(Funs, {F, A})
-    end, AllDocs).
+file(Forms) ->
+    [{_Ln, File}, _Loc] = hd(attributes(file, Forms)),
+    File.
 
 doctest(Attrs, SrcFile) ->
     parse_to_doctest(Attrs, SrcFile, #doctest{
@@ -68,55 +64,16 @@ doctest(Attrs, SrcFile) ->
         eunit = default
     }).
 
-parse_to_doctest([Enabled | T], SrcFile, DocTest) when is_boolean(Enabled) ->
-    parse_to_doctest(T, SrcFile, DocTest#doctest{enabled = Enabled});
-parse_to_doctest([Funs | T], SrcFile, DocTest) when is_list(Funs) ->
-    parse_to_doctest(T, SrcFile, DocTest#doctest{funs = Funs});
-parse_to_doctest([{enabled, Enabled} | T], SrcFile, DocTest) when is_boolean(Enabled) ->
-    parse_to_doctest(T, SrcFile, DocTest#doctest{enabled = Enabled});
-parse_to_doctest([{moduledoc, Enabled} | T], SrcFile, DocTest) when is_boolean(Enabled) ->
-    parse_to_doctest(T, SrcFile, DocTest#doctest{moduledoc = Enabled});
-parse_to_doctest([{funs, Enabled} | T], SrcFile, DocTest) when is_boolean(Enabled)->
-    parse_to_doctest(T, SrcFile, DocTest#doctest{funs = Enabled});
-parse_to_doctest([{funs, Funs} | T], SrcFile, DocTest) when is_list(Funs) ->
-    parse_to_doctest(T, SrcFile, DocTest#doctest{funs = Funs});
-parse_to_doctest([{eunit, Eunit} | T], SrcFile, DocTest) ->
-    parse_to_doctest(T, SrcFile, DocTest#doctest{eunit = Eunit});
-parse_to_doctest([Map | T], SrcFile, DocTest) when is_map(Map) ->
-    parse_to_doctest(T, SrcFile, DocTest#doctest{
-        enabled = maps:get(enabled, Map, DocTest#doctest.enabled),
-        moduledoc = maps:get(moduledoc, Map, DocTest#doctest.moduledoc),
-        funs = maps:get(funs, Map, DocTest#doctest.funs),
-        eunit = maps:get(eunit, Map, DocTest#doctest.eunit)
-    });
-parse_to_doctest([], _SrcFile, #doctest{} = DocTest) ->
-    DocTest.
-
-tests(File, Forms, Docs) ->
-    lists:foldl(fun({Kind, {MdLn, Md}}, Acc) ->
-        case doctest:code_blocks(Md) of
-            {ok, CodeBlocks} ->
-                {ok, M, Bin} = compile:forms(Forms, [
-                    {i, "eunit/include/eunit.hrl"}
-                ]),
-                {module, M} = code:load_binary(M, File, Bin),
-                case Kind of
-                    moduledoc ->
-                        [doctest:parse_mod(M, MdLn, CodeBlocks) | Acc];
-                    {doc, {function, {F, A, Ln}}} ->
-                        [doctest:parse_fun({M, F, A}, Ln, CodeBlocks) | Acc]
-                end;
-            none ->
-                Acc
-        end
-    end, [], Docs).
-
-file(Forms) ->
-    [{_Ln, File}, _Loc] = hd(attributes(file, Forms)),
-    File.
-
 doctest_attrs(Forms) ->
     [Attr || {_Ln, Attr} <- attributes(doctest, Forms)].
+
+docs(#doctest{moduledoc = ShouldTestModDoc, funs = Funs}, AllDocs) ->
+    lists:filter(fun
+        ({moduledoc, _Doc}) ->
+            ShouldTestModDoc;
+        ({{doc, {function, {F, A, _Ln}}}, _Doc}) ->
+            doctest:should_test_function(Funs, {F, A})
+    end, AllDocs).
 
 doc_attrs(Forms) ->
     do_doc_attrs(filtermap_forms(
@@ -155,6 +112,52 @@ do_doc_attrs([{function, _} | T], Acc) ->
     do_doc_attrs(T, Acc);
 do_doc_attrs([], Acc) ->
     Acc.
+
+tests(File, Forms, Docs) ->
+    lists:foldl(fun({Kind, {MdLn, Md}}, Acc) ->
+        case doctest:code_blocks(Md) of
+            {ok, CodeBlocks} ->
+                {ok, M, Bin} = compile:forms(Forms, [
+                    {i, "eunit/include/eunit.hrl"}
+                ]),
+                {module, M} = code:load_binary(M, File, Bin),
+                case Kind of
+                    moduledoc ->
+                        [doctest:parse_mod(M, MdLn, CodeBlocks) | Acc];
+                    {doc, {function, {F, A, Ln}}} ->
+                        [doctest:parse_fun({M, F, A}, Ln, CodeBlocks) | Acc]
+                end;
+            none ->
+                Acc
+        end
+    end, [], Docs).
+
+test(Tests, DocTest) ->
+    doctest_eunit:test(Tests, DocTest#doctest.eunit).
+
+parse_to_doctest([Enabled | T], SrcFile, DocTest) when is_boolean(Enabled) ->
+    parse_to_doctest(T, SrcFile, DocTest#doctest{enabled = Enabled});
+parse_to_doctest([Funs | T], SrcFile, DocTest) when is_list(Funs) ->
+    parse_to_doctest(T, SrcFile, DocTest#doctest{funs = Funs});
+parse_to_doctest([{enabled, Enabled} | T], SrcFile, DocTest) when is_boolean(Enabled) ->
+    parse_to_doctest(T, SrcFile, DocTest#doctest{enabled = Enabled});
+parse_to_doctest([{moduledoc, Enabled} | T], SrcFile, DocTest) when is_boolean(Enabled) ->
+    parse_to_doctest(T, SrcFile, DocTest#doctest{moduledoc = Enabled});
+parse_to_doctest([{funs, Enabled} | T], SrcFile, DocTest) when is_boolean(Enabled)->
+    parse_to_doctest(T, SrcFile, DocTest#doctest{funs = Enabled});
+parse_to_doctest([{funs, Funs} | T], SrcFile, DocTest) when is_list(Funs) ->
+    parse_to_doctest(T, SrcFile, DocTest#doctest{funs = Funs});
+parse_to_doctest([{eunit, Eunit} | T], SrcFile, DocTest) ->
+    parse_to_doctest(T, SrcFile, DocTest#doctest{eunit = Eunit});
+parse_to_doctest([Map | T], SrcFile, DocTest) when is_map(Map) ->
+    parse_to_doctest(T, SrcFile, DocTest#doctest{
+        enabled = maps:get(enabled, Map, DocTest#doctest.enabled),
+        moduledoc = maps:get(moduledoc, Map, DocTest#doctest.moduledoc),
+        funs = maps:get(funs, Map, DocTest#doctest.funs),
+        eunit = maps:get(eunit, Map, DocTest#doctest.eunit)
+    });
+parse_to_doctest([], _SrcFile, #doctest{} = DocTest) ->
+    DocTest.
 
 attributes(Name, Forms) ->
     filtermap_forms(

--- a/src/doctest_parse_transform.erl
+++ b/src/doctest_parse_transform.erl
@@ -43,7 +43,7 @@ parse_transform(Forms, _Opt) ->
     % Parse docs and run tests
     File = file(Forms),
     Docs = docs(doctest(doctest_attrs(Forms), File), doc_attrs(Forms)),
-    doctest:run(tests(File, Forms, Docs)),
+    doctest_eunit:test(tests(File, Forms, Docs)),
     % Return the original forms
 	Forms.
 


### PR DESCRIPTION
This PR permits defining custom `eunit` options.
By default, it tries to resolve `rebar3` options.