### PR TITLE
Provide global options

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ Options are defined via the `-doctest` attribute and can be defined multiple tim
   }.
   ```
 
+### Global options
+
+Options can be globally defined via a [config file](https://www.erlang.org/doc/man/config.html), e.g.:
+```erlang
+% config/sys.config
+[{doctest, [
+    {enabled, true},
+    {moduledoc, false},
+    {funs, true},
+    {eunit, [no_tty, {report, {eunit_progress, [colored, profile]}}]}
+]}].
+```
+
 ### EUnit options
 
 Valid EUnit options are the `resolve` atom and a proplist.

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {minimum_otp_vsn, "27"}.
 
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, warnings_as_errors]}.
 
 {dialyzer, [
     % Fixes a bug on 'doctest_eunit':

--- a/src/doctest.erl
+++ b/src/doctest.erl
@@ -45,11 +45,12 @@ module(Mod) ->
 -spec module(module(), options()) -> test_result().
 
 module(Mod, Opts) when is_atom(Mod), is_map(Opts) ->
-    ShouldTestModDoc = maps:get(moduledoc, Opts, true),
-    FunsOpts = maps:get(funs, Opts, true),
+    Env = application:get_all_env(doctest),
+    ShouldTestModDoc = maps:get(moduledoc, Opts, proplists:get_value(moduledoc, Env, true)),
+    FunsOpts = maps:get(funs, Opts, proplists:get_value(funs, Env, true)),
     case doctest_parse:module_tests(Mod, ShouldTestModDoc, FunsOpts) of
         {ok, Tests} ->
-            EunitOpts = maps:get(eunit, Opts, resolve),
+            EunitOpts = maps:get(eunit, Opts, proplists:get_value(eunit, Env, resolve)),
             doctest_eunit:test(Tests, EunitOpts);
         {error, Reason} ->
             {error, Reason}


### PR DESCRIPTION
This PR provides global options via [config file](https://www.erlang.org/doc/man/config.html) and also sets `warnings_as_errors.`