### PR TITLE
Provide a better format error info

### DIFF
--- a/src/doctest_eunit.erl
+++ b/src/doctest_eunit.erl
@@ -66,10 +66,10 @@ moduledoc_tests(Mod, AttrLn, CodeBlocks) ->
     ) of
         {ok, Tests} ->
             Tests;
-        {error, Reason} ->
-            error({doctest, {moduledoc, Reason}}, [
-                Mod, AttrLn, CodeBlocks
-            ])
+        {error, {format, Info}} ->
+            error({doctest, {moduledoc_format, Info#{
+                module => Mod
+            }}}, [Mod, AttrLn, CodeBlocks])
     end.
 
 doc_tests({M, F, A}, AttrLn, CodeBlocks) ->
@@ -101,10 +101,12 @@ doc_tests({M, F, A}, AttrLn, CodeBlocks) ->
     ) of
         {ok, Tests} ->
             Tests;
-        {error, Reason} ->
-            error({doctest, {doc, Reason}}, [
-                {M, F, A}, AttrLn, CodeBlocks
-            ])
+        {error, {format, Info}} ->
+            error({doctest, {doc_format, Info#{
+                module => M,
+                function => F,
+                arity => A
+            }}}, [{M, F, A}, AttrLn, CodeBlocks])
     end.
 
 test_title(Mod, Ln) ->

--- a/src/doctest_eunit_report.erl
+++ b/src/doctest_eunit_report.erl
@@ -263,6 +263,8 @@ print_output(#{output := Out}) ->
             ])
     end.
 
+format_error({error, {doctest, Error}, Stack}, _Test) ->
+    erlang:raise(error, {doctest, Error}, Stack);
 format_error({error, {assertEqual, Info}, Stack}, Test) ->
     case proplists:lookup(doctest, Info) of
         {doctest, DocTest} ->

--- a/src/doctest_md.erl
+++ b/src/doctest_md.erl
@@ -90,12 +90,6 @@ chunks(Parts) ->
         end
     end, Parts).
 
-% TODO: Maybe check for the correct line sequence by starting from 1, e.g.:
-%       1> ok.
-%       2> ok.
-%       And this should be wrong:
-%       9> error.
-%       8> error.
 asserts([{left, {N, L}}, {more, {Ws, M}} | T], HI, {Ln, NLn}, Acc) ->
     case check_more_format(Ws, N) of
         ok ->


### PR DESCRIPTION
An example of a `moduledoc` error when the line sequence is wrong:
```erlang
=ERROR REPORT==== 22-May-2024::23:27:42.877355 ===
Error in process <0.320.0> with exit value:
{{doctest,{moduledoc_format,#{line => 24,module => foo,
                              expected => <<"2> foo:foo()">>,
                              received => <<"3> foo:foo()">>}}},
 [{doctest_eunit,moduledoc_tests,
                 [foo,17,
                  [{<<"1> foo:foo()\n.. =:= bar.\nfalse\n3> foo:foo()\n.. =:=\n.. foo.\ntrue">>,
                    {4,1}}]],
                 [{file,"/home/williamthome/Projects/williamthome/doctest/src/doctest_eunit.erl"},
                  {line,70}]},
  {doctest_parse,module_tests,3,
                 [{file,"/home/williamthome/Projects/williamthome/doctest/src/doctest_parse.erl"},
                  {line,36}]},
  {doctest,module,2,
           [{file,"/home/williamthome/Projects/williamthome/doctest/src/doctest.erl"},
            {line,51}]},
  {doctest_test,module_test,0,
                [{file,"/home/williamthome/Projects/williamthome/doctest/test/doctest_test.erl"},
                 {line,21}]},
  {eunit_test,'-mf_wrapper/2-fun-0-',2,[{file,"eunit_test.erl"},{line,274}]},
  {eunit_test,run_testfun,1,[{file,"eunit_test.erl"},{line,72}]},
  {eunit_proc,run_test,1,[{file,"eunit_proc.erl"},{line,544}]},
  {eunit_proc,with_timeout,3,[{file,"eunit_proc.erl"},{line,369}]}]}
```