### PR TITLE
Fix comment not attached to function form

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [23, 24, 25, 26, 27]
+        otp_version: [24, 25, 26, 27]
         os: [ubuntu-latest]
 
     container:

--- a/README.md
+++ b/README.md
@@ -279,18 +279,6 @@ An example of the `doctest_eunit_report` output:
 - [ ] Specs
 - [ ] Improve docs
 
-### FIXME
-
-- [ ] Line break unlinks doc and function in EDoc, e.g.:
-    ```erlang
-    %% @doc this is fine.
-    foo() -> foo.
-
-    %% @doc this does not link the doc and the function because of the line break.
-
-    foo() -> foo.
-    ```
-
 ## Sponsors
 
 If you like this tool, please consider [sponsoring me](https://github.com/sponsors/williamthome).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An Erlang library to test `@doc` tags and `-moduledoc` and `-doc` attributes.
 
 ```erlang
 % rebar.config
-% {minimum_otp_vsn, "23"}.
+% {minimum_otp_vsn, "24"}.
 {profiles, [
     {test, [
         % 'debug_info' is required to extract doc chunks.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "23"}.
+{minimum_otp_vsn, "24"}.
 
 {erl_opts, [debug_info, warnings_as_errors]}.
 

--- a/src/doctest_check.hrl
+++ b/src/doctest_check.hrl
@@ -1,19 +1,11 @@
 -ifdef(OTP_RELEASE).
-    -if(?OTP_RELEASE < 27).
-        -define(IS_DOC_ATTRS_SUPPORTED, false).
-    -else.
-        -define(IS_DOC_ATTRS_SUPPORTED, true).
-    -endif.
+    -define(IS_DOC_ATTRS_SUPPORTED, ?OTP_RELEASE >= 27).
 -else.
     -define(IS_DOC_ATTRS_SUPPORTED, false).
 -endif.
 
 -ifdef(OTP_RELEASE).
-    -if(?OTP_RELEASE < 24).
-        -define(IS_ERROR_INFO_SUPPORTED, false).
-    -else.
-        -define(IS_ERROR_INFO_SUPPORTED, true).
-    -endif.
+    -define(IS_ERROR_INFO_SUPPORTED, ?OTP_RELEASE >= 24).
 -else.
     -define(IS_ERROR_INFO_SUPPORTED, false).
 -endif.

--- a/src/doctest_eunit.erl
+++ b/src/doctest_eunit.erl
@@ -163,7 +163,7 @@ rebar3_config_opts() ->
     end.
 
 tests(Mod, AttrLn, CodeBlocks, Callback) when
-    is_atom(Mod), is_integer(AttrLn), AttrLn > 0,
+    is_atom(Mod), is_integer(AttrLn), AttrLn >= 0,
     is_list(CodeBlocks), is_function(Callback, 2) ->
     {ok, lists:foldl(fun({CodeBlock, {CBLn, _CBCol}}, Acc) ->
         case code_block_asserts(CodeBlock, AttrLn + CBLn) of

--- a/src/doctest_eunit_report.erl
+++ b/src/doctest_eunit_report.erl
@@ -273,7 +273,9 @@ format_error({error, {assertEqual, Info}, Stack}, Test) ->
             print_test({assertEqual, Info}, Test, Stack)
     end;
 format_error({error, {Reason, Info}, Stack}, Test) ->
-    print_test({Reason, Info}, Test, Stack).
+    print_test({Reason, Info}, Test, Stack);
+format_error({exit, Reason, Stack}, Test) ->
+    print_test({exit, Reason}, Test, Stack).
 
 print_doctest(#{ln_range := {FromLn, ToLn}} = _DocTest, {ErrReason, Info}, Test, _Stack) ->
     Left = proplists:get_value(expected, Info),

--- a/src/doctest_eunit_report.erl
+++ b/src/doctest_eunit_report.erl
@@ -256,7 +256,6 @@ print_output(#{output := Out}) ->
             Pd = <<"\s\s\s">>,
             Lns = binary:split(Comment, [<<"\r">>, <<"\n">>, <<"\r\n">>], [global]),
             doctest_term:write([
-                % <<"\n\n">>,
                 Pd, {<<"Output:\n">>, bold},
                 lists:join(<<"\n">>, lists:map(fun(Ln) ->
                     [Pd, {Ln, {fg, bright_black}}]

--- a/src/doctest_eunit_report.erl
+++ b/src/doctest_eunit_report.erl
@@ -253,11 +253,13 @@ print_output(#{output := Out}) ->
         <<>> ->
             ok;
         Comment ->
+            Pd = <<"\s\s\s">>,
             Lns = binary:split(Comment, [<<"\r">>, <<"\n">>, <<"\r\n">>], [global]),
             doctest_term:write([
-                <<"\n\n">>,
+                % <<"\n\n">>,
+                Pd, {<<"Output:\n">>, bold},
                 lists:join(<<"\n">>, lists:map(fun(Ln) ->
-                    [{<<"%\s">>, {fg, bright_black}}, {Ln, {fg, bright_black}}]
+                    [Pd, {Ln, {fg, bright_black}}]
                 end, Lns))
             ])
     end.

--- a/src/doctest_eunit_report.erl
+++ b/src/doctest_eunit_report.erl
@@ -277,15 +277,12 @@ format_error({error, {Reason, Info}, Stack}, Test) ->
 print_doctest(#{ln_range := {FromLn, ToLn}} = _DocTest, {ErrReason, Info}, Test, _Stack) ->
     Left = proplists:get_value(expected, Info),
     Right = proplists:get_value(value, Info),
-
     Filename = maps:get(file, Test),
     Lns = readlines(Filename),
     Pd = iolist_to_binary(lists:duplicate(byte_size(integer_to_binary(ToLn)), <<"\s">>)),
-
     Range = lists:map(fun({RLn, RExpr}) ->
         [<<"\s">>, {{to_bin, RLn}, {fg, red}}, <<"\s">>, {<<"│"/utf8>>, {fg, bright_black}}, <<"\s">>, RExpr, <<"\n">>]
     end, range(FromLn, ToLn, Lns)),
-
     [
         <<"\s">>, Pd, <<"\s❌\s"/utf8>>, {{to_bin, ErrReason}, {fg, bright_black}}, <<"\n">>,
         <<"\n">>,
@@ -311,7 +308,6 @@ print_test({ErrReason, Info}, Test, _Stacktrace) ->
             Right = proplists:get_value(value, Info,
                         proplists:get_value(unexpected_success, Info,
                             proplists:get_value(unexpected_exception, Info))),
-
             LeftFmt = case proplists:is_defined(pattern, Info) of
                 true ->
                     "~ts";
@@ -319,14 +315,11 @@ print_test({ErrReason, Info}, Test, _Stacktrace) ->
                     "~tp"
             end,
             RightFmt = "~tP",
-
             Filename = maps:get(file, Test),
             {line, Ln} = proplists:lookup(line, Info),
             Lns = readlines(Filename),
             LnExpr = lists:nth(Ln, Lns),
-
             Pd = iolist_to_binary(lists:duplicate(byte_size(integer_to_binary(Ln)), <<"\s">>)),
-
             [
                 <<"\s">>, Pd, <<"\s❌\s"/utf8>>, {{to_bin, ErrReason}, {fg, bright_black}}, <<"\n">>,
                 <<"\n">>,

--- a/src/doctest_extract_tag.erl
+++ b/src/doctest_extract_tag.erl
@@ -41,7 +41,7 @@ chunks({Mod, Forms}) ->
         EntryComments = search_entry_comments(Ln, Comments),
         Doc = comments_to_binary(EntryComments),
         case Data of
-            module ->
+            moduledoc ->
                 {token(Mod), Ln-1, Doc};
             {doc, {F, A}} ->
                 {token({Mod, F, A}), Ln-1, Doc}

--- a/src/doctest_extract_tag.erl
+++ b/src/doctest_extract_tag.erl
@@ -25,6 +25,9 @@
     "(?:\\n^(''')(\\s+|\\n|$))" % ''')
 ).
 
+% Contains the entry record.
+-include_lib("edoc/src/edoc.hrl").
+
 %%%=====================================================================
 %%% doctest_extract callbacks
 %%%=====================================================================
@@ -32,8 +35,18 @@
 chunks({Mod, Forms}) ->
     Filename = doctest_forms:filename(Forms),
     Comments = erl_comment_scan:file(Filename),
-    Tree = erl_recomment:recomment_forms(Forms, Comments),
-    do_chunks(Mod, Tree).
+    {Mod, _EDoc, Entries} =
+        edoc_extract:source(Filename, edoc_lib:get_doc_env([]), [return_entries]),
+    lists:map(fun({Ln, Data}) ->
+        EntryComments = search_entry_comments(Ln, Comments),
+        Doc = comments_to_binary(EntryComments),
+        case Data of
+            module ->
+                {token(Mod), Ln-1, Doc};
+            {doc, {F, A}} ->
+                {token({Mod, F, A}), Ln-1, Doc}
+        end
+    end, filtermap_entries(Entries)).
 
 code_blocks(Doc) ->
     doctest_extract:code_blocks(Doc, ?CODE_BLOCK_RE).
@@ -42,46 +55,35 @@ code_blocks(Doc) ->
 %%% Internal functions
 %%%=====================================================================
 
-do_chunks(Mod, Tree) ->
-    Forms = erl_syntax:form_list_elements(erl_syntax:flatten_form_list(Tree)),
-    do_chunks_1(Forms, Mod).
-
-do_chunks_1([Form | Forms], Mod) ->
-    case erl_syntax:get_precomments(Form) of
-        [] ->
-            do_chunks_1(Forms, Mod);
-        Comments ->
-            do_chunks_2(Form, Forms, Mod, Comments)
-    end;
-do_chunks_1([], _Mod) ->
+filtermap_entries([#entry{data = []} | Entries]) ->
+    filtermap_entries(Entries);
+filtermap_entries([#entry{name = module, data = Data} | Entries]) ->
+    [{entry_ln(Data), moduledoc} | filtermap_entries(Entries)];
+filtermap_entries([#entry{name = {F, A}, data = Data} | Entries]) ->
+    [{entry_ln(Data), {doc, {F, A}}} | filtermap_entries(Entries)];
+filtermap_entries([_ | Entries]) ->
+    filtermap_entries(Entries);
+filtermap_entries([]) ->
     [].
 
-do_chunks_2(Form, Forms, Mod, Comments) ->
-    case erl_syntax_lib:analyze_form(Form) of
-        {function, {Fun, Arity}} ->
-            [chunk({Mod, Fun, Arity}, Comments) | do_chunks_1(Forms, Mod)];
-        {attribute, {module, Mod}} ->
-            [chunk(Mod, Comments) | do_chunks_1(Forms, Mod)];
-        _ ->
-            do_chunks_1(Forms, Mod)
-    end.
-
-chunk(Data, Comments) ->
-    {token(Data), ln(Comments), doc(Comments)}.
+entry_ln([#tag{name = doc, origin = comment, line = Ln} | _]) ->
+    Ln;
+entry_ln([_ | Elems]) ->
+    entry_ln(Elems).
 
 token({Mod, Fun, Arity}) ->
     {doc, {Mod, Fun, Arity}, <<"@doc">>};
 token(Mod) ->
     {moduledoc, Mod, <<"@moduledoc">>}.
 
-doc(Comments) ->
-    iolist_to_binary(lists:join($\n, lists:map(fun(C) ->
-        lists:join($\n, [rm_percentage(T) || T <- erl_syntax:comment_text(C)])
-    end, Comments))).
+search_entry_comments(Ln, Comments) ->
+    {value, {_, _, _, EntryComments}} =
+        lists:search(fun({CLn, _, _, _}) -> CLn =:= Ln end, Comments),
+    EntryComments.
+
+comments_to_binary(Comments) ->
+    iolist_to_binary(lists:join($\n, [rm_percentage(C) || C <- Comments])).
 
 rm_percentage([$% | Cs]) -> rm_percentage(Cs);
 rm_percentage([$\s | Cs]) -> Cs;
 rm_percentage(Cs) -> Cs.
-
-ln([H|_]) ->
-    erl_anno:line(erl_syntax:get_pos((H))) - 1.

--- a/src/doctest_forms.erl
+++ b/src/doctest_forms.erl
@@ -111,7 +111,9 @@ do_prepend([Form | Forms], NewForms) ->
             NewForms ++ [Form | Forms];
         _ ->
             [Form | do_prepend(Forms, NewForms)]
-    end.
+    end;
+do_prepend([], _NewForms) ->
+    [].
 
 do_append([Form | Forms], NewForms) ->
     case erl_syntax:type(Form) of
@@ -119,4 +121,6 @@ do_append([Form | Forms], NewForms) ->
             NewForms ++ [Form | Forms];
         _ ->
             [Form | do_append(Forms, NewForms)]
-    end.
+    end;
+do_append([], _NewForms) ->
+    [].

--- a/test/doctest_transform_test.erl
+++ b/test/doctest_transform_test.erl
@@ -1,4 +1,10 @@
-%%%---------------------------------------------------------------------
+%%% @doc Module doc can also be tested.
+%%% ```
+%%% 1> doctest_transform_test:sum(1, 1) =:= 2.
+%%% true
+%%% '''
+%%% @end
+%%% ---------------------------------------------------------------------
 %%% Copyright 2024 William Fank Thomé
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,27 +20,17 @@
 %%% limitations under the License.
 %%%---------------------------------------------------------------------
 -module(doctest_transform_test).
--include("src/doctest_check.hrl").
-
--if(?IS_DOC_ATTRS_SUPPORTED).
--moduledoc """
-Module doc tags can also be tested.
-
-```erlang
-1> doctest_transform_test:sum(1, 1) =:= 2.
-true
-```
-""".
--endif.
-
--export([sum/2, mult/2, nodoc/0, nocodeblock/0, notestcodeblock/0, concat/2]).
+-export([sum/2, mult/2, nodoc/0, nocodeblock/0, notestcodeblock/0]).
 
 -ifdef(TEST).
 -include("doctest.hrl").
--doctest [sum/2, mult/2, nodoc/0, nocodeblock/0, notestcodeblock/0, concat/2].
+-doctest [sum/2, mult/2, nodoc/0, nocodeblock/0, notestcodeblock/0].
 -endif.
 
+-include("src/doctest_check.hrl").
+
 -if(?IS_DOC_ATTRS_SUPPORTED).
+
 -doc """
 ```erlang
 1> doctest_transform_test:sum(1, 1).
@@ -44,57 +40,91 @@ true
 3
 ```
 """.
--endif.
 sum(A, B) ->
     A + B.
 
--if(?IS_DOC_ATTRS_SUPPORTED).
 -doc """
 ```erlang
-1> doctest_transform_test:mult(1, 1).
+1> One = 1.
 1
-2> doctest_transform_test:mult(1,
+2> doctest_transform_test:mult(One, One).
+1
+3> doctest_transform_test:mult(One,
 .. 2).
 2
 ```
 """.
--endif.
 mult(A, B) ->
     A * B.
 
 nodoc() ->
     ok.
 
--if(?IS_DOC_ATTRS_SUPPORTED).
 -doc """
 """.
--endif.
 nocodeblock() ->
     ok.
 
--if(?IS_DOC_ATTRS_SUPPORTED).
 -doc """
 ```erlang
 foo() ->
     bar.
 ```
 """.
--endif.
 notestcodeblock() ->
     ok.
 
--if(?IS_DOC_ATTRS_SUPPORTED).
--doc """
-```erlang
-1> Foo = "foo".
-"foo"
-2> doctest_transform_test:concat(
-.. Foo,
-..   "bar"
-.. ).
-"foobar"
-```
-""".
--endif.
+-else.
+
+%% @doc
+%% ```
+%% 1> doctest_transform_test:sum(1, 1).
+%% 2
+%% 2> doctest_transform_test:sum(1,
+%% .. 2).
+%% 3
+%% '''
+sum(A, B) ->
+    A + B.
+
+%% @doc
+%% ```
+%% 1> doctest_transform_test:mult(1, 1).
+%% 1
+%% 2> doctest_transform_test:mult(1,
+%% .. 2).
+%% 2
+%% '''
+mult(A, B) ->
+    A * B.
+
+nodoc() ->
+    ok.
+
+%% @doc
+%% '''
+nocodeblock() ->
+    ok.
+
+%% @doc
+%% ```
+%% foo() ->
+%%     bar.
+%% '''
+notestcodeblock() ->
+    ok.
+
+%% @doc
+%% ```
+%% 1> Foo = "foo".
+%% "foo"
+%% 2> doctest_transform_test:concat(
+%% .. Foo,
+%% ..   "bar"
+%% .. ).
+%% "foobar"
+%% '''
 concat(A, B) ->
     A ++ B.
+
+-endif.

--- a/test/support/doctest_test_module.erl
+++ b/test/support/doctest_test_module.erl
@@ -60,6 +60,6 @@ foo() ->
 %% 2> Bar =:= bar.
 %% true
 %% '''
-%% @todo Check why no line break is allowed between doc and function.
+
 bar() ->
     bar.


### PR DESCRIPTION
This PR fixes the issue where line breaks were not permitted between EDoc and functions, but the approach is only supported for OTP >= 24.