### PR TITLE
Skip private functions

### DIFF
--- a/include/doctest.hrl
+++ b/include/doctest.hrl
@@ -1,3 +1,1 @@
-% NOTE: export_all is required to test private functions.
--compile([export_all, nowarn_export_all]).
 -compile({parse_transform, doctest_transform}).

--- a/src/doctest_eunit.erl
+++ b/src/doctest_eunit.erl
@@ -170,12 +170,6 @@ tests(Mod, AttrLn, CodeBlocks, Callback) when
                     fun({{Left, LeftLn}, {Right, RightLn}}, {Bindings, Acc1}) ->
                         {LeftValue, NewBindings} = eval(Left, LeftLn, Bindings, {value,
                             fun(Name, Args) ->
-                                % TODO: Maybe warn about testing non-exported functions.
-                                % logger:warning(<<"testing a private function">>, #{
-                                %     mfa => {Mod, Fun, Arity},
-                                %     file => Filename,
-                                %     line => LeftLn
-                                % }),
                                 erlang:apply(Mod, Name, Args)
                             end
                         }),

--- a/src/doctest_extract.erl
+++ b/src/doctest_extract.erl
@@ -125,7 +125,7 @@ test_cases(Extractor, Chunks, Opts) ->
     lists:filtermap(fun({Kind, Ln, Doc}) ->
         case {Extractor:code_blocks(Doc), Kind} of
             {{ok, CodeBlocks}, {doc, {M, F, A}, Tag}} ->
-                case should_test_doc(Opts, {F, A}) of
+                case should_test_doc({M, F, A}, Opts) of
                     true ->
                         {true, {Ln, doctest_eunit:doc_tests({M, F, A}, Ln, CodeBlocks, Tag)}};
                     false ->
@@ -155,13 +155,21 @@ should_test_moduledoc(#{moduledoc := false}) ->
 should_test_moduledoc(Opts) when not is_map_key(moduledoc, Opts) ->
     true.
 
-should_test_doc(#{doc := true}, _Fun) ->
+should_test_doc({M, F, A}, Opts) ->
+    case erlang:function_exported(M, F, A) of
+        true ->
+            do_should_test_doc(Opts, {F, A});
+        false ->
+            false
+    end.
+
+do_should_test_doc(#{doc := true}, _Fun) ->
     true;
-should_test_doc(#{doc := false}, _Fun) ->
+do_should_test_doc(#{doc := false}, _Fun) ->
     false;
-should_test_doc(#{doc := Funs}, Fun) when is_list(Funs) ->
+do_should_test_doc(#{doc := Funs}, Fun) when is_list(Funs) ->
     lists:member(Fun, Funs);
-should_test_doc(Opts, _Fun) when not is_map_key(doc, Opts) ->
+do_should_test_doc(Opts, _Fun) when not is_map_key(doc, Opts) ->
     true.
 
 loc(Doc, Pos) ->

--- a/test/doctest_transform_test.erl
+++ b/test/doctest_transform_test.erl
@@ -114,17 +114,4 @@ nocodeblock() ->
 notestcodeblock() ->
     ok.
 
-%% @doc
-%% ```
-%% 1> Foo = "foo".
-%% "foo"
-%% 2> doctest_transform_test:concat(
-%% .. Foo,
-%% ..   "bar"
-%% .. ).
-%% "foobar"
-%% '''
-concat(A, B) ->
-    A ++ B.
-
 -endif.

--- a/test/support/doctest_test_module.erl
+++ b/test/support/doctest_test_module.erl
@@ -37,13 +37,13 @@ true
 
 -if(?IS_DOC_ATTRS_SUPPORTED).
 -doc """
-Foo
+Test #1
 ```erlang
 1> % Test non-exported functions is allowed.
 .. foo().
 foo
 ```
-Bar
+Test #2
 ```erlang
 1> doctest_test_module:foo() =:= foo.
 true
@@ -51,6 +51,15 @@ true
 """.
 -endif.
 foo() ->
+    do_foo().
+
+%% @doc This function is private and should be skipped.
+%% ```
+%% 1> do_foo().
+%% foo
+%% '''
+
+do_foo() ->
     foo.
 
 %% @doc Comments are also supported.


### PR DESCRIPTION
Closes #46.

Private functions cannot be documented, so they are not testable.