### PR TITLE
Move `CODE_BLOCK_RE` to header file...

### DIFF
--- a/src/doctest_extract.hrl
+++ b/src/doctest_extract.hrl
@@ -1,0 +1,6 @@
+-define(CODE_BLOCK_RE,
+    "(?ms)^(```[`]*)(?:erlang)?\\s*\\n" % ```erlang
+    "(.*?)"                             % <erlang-code>
+    "(?:\\n^(\\1)(\\s+|\\n|$))"         % ```
+).
+

--- a/src/doctest_extract_attr.erl
+++ b/src/doctest_extract_attr.erl
@@ -19,11 +19,8 @@
 % doctest_extract callbacks
 -export([chunks/1, code_blocks/1]).
 
--define(CODE_BLOCK_RE,
-    "(?ms)^(```[`]*)(?:erlang)?\\s*\\n" % ```erlang
-    "(.*?)"                        % <erlang-code>
-    "(?:\\n^(\\1)(\\s+|\\n|$))"    % ```
-).
+% Contains CODE_BLOCK_RE
+-include("doctest_extract.hrl").
 
 % Contains the docs_v1 record.
 -include_lib("kernel/include/eep48.hrl").

--- a/src/doctest_extract_tag.erl
+++ b/src/doctest_extract_tag.erl
@@ -19,11 +19,8 @@
 % doctest_extract callbacks
 -export([chunks/1, code_blocks/1]).
 
--define(CODE_BLOCK_RE,
-    "(?ms)^(```)\\s*\\n"        % ```
-    "(.*?)"                     % <erlang-code>
-    "(?:\\n^(''')(\\s+|\\n|$))" % ''')
-).
+% Contains CODE_BLOCK_RE
+-include("doctest_extract.hrl").
 
 % Contains the entry record.
 -include_lib("edoc/src/edoc.hrl").


### PR DESCRIPTION
And include it where necessary.  This also _should_ ensure `attr` and `tag` extraction of code blocks are identical.

> Note: `rebar3 eunit` shows all current tests still pass so this _shouldn't_ be a breaking change :crossed_fingers: 