### PR TITLE
Add `print_depth` option to the EUnit reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,13 @@ tests results correctly. Set it in the EUnit options of the project options, e.g
 
 ```erlang
 % rebar3.config
-{eunit_opts, [no_tty, {report, {doctest_eunit_report, []}}]}.
+{eunit_opts, [
+    no_tty,
+    {report, {doctest_eunit_report, [
+        % Default options
+        {print_depth, 15}
+    ]}}
+]}.
 ```
 
 An example of the `doctest_eunit_report` output:


### PR DESCRIPTION
Sometimes the content is truncated when an error occurs and is not desirable, for example:

```erlang
[<<"<html>\n    <head></head>\n    <body id=\"">>,<<"app">>,<<"\">">>,
 [<<"<div id=\"">>,<<"counter">>,<<"\">">>,<<"0">>,<<>>,
  [<<"<button>">>,<<"Incremen"...>>,<<"</bu"...>>],
  <<"</div>">>],
 <<"</body>\n</html>">>]
```

Note the `...` on the 3rd line.

Increasing this value will display it as:

```erlang
[<<"<html>\n    <head></head>\n    <body id=\"">>,<<"app">>,<<"\">">>,
 [<<"<div id=\"">>,<<"counter">>,<<"\">">>,<<"0">>,<<>>,
  [<<"<button>">>,<<"Increment">>,<<"</button>">>],
  <<"</div>">>],
 <<"</body>\n</html>">>]
```