### PR TITLE
Introduce records option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,12 @@ doctest_test() ->
 
         % Bind value to variables. Could be a proplist or a map.
         % Spec: erl_eval:binding_struct()
-        bindings => #{}
+        bindings => #{},
+
+        % Define records to be expanded/compiled to tuple expressions.
+        % Spec: [{Name :: atom(), Fields :: [atom()]}]
+        % Example: [{RecName, record_info(fields, RecName)}]
+        records => []
     }).
 -endif.
 

--- a/src/doctest.erl
+++ b/src/doctest.erl
@@ -25,7 +25,8 @@
     doc => boolean() | [{atom(), arity()}],
     eunit_opts => rebar3_config | [term()],
     extractors => [module()],
-    bindings => erl_eval:binding_struct()
+    bindings => erl_eval:binding_struct(),
+    records => [{Name :: atom(), Fields :: [atom()]}]
 }.
 -type result() :: ok | error.
 
@@ -59,7 +60,8 @@ parse_opts(Opts) ->
         doc => maps:get(doc, Opts, true),
         eunit_opts => maps:get(eunit_opts, Opts, rebar3_config),
         extractors => maps:get(extractors, Opts, default_extractors()),
-        bindings => maps:get(bindings, Opts, #{})
+        bindings => maps:get(bindings, Opts, #{}),
+        records => maps:get(records, Opts, [])
     }.
 
 -if(?OTP_RELEASE >= 27).

--- a/src/doctest_extract.erl
+++ b/src/doctest_extract.erl
@@ -72,19 +72,20 @@ all_test_cases(Extractors, Args, Opts) ->
 
 test_cases(Extractor, Chunks, Opts) ->
     Bindings = maps:get(bindings, Opts, #{}),
+    Records = maps:get(records, Opts, []),
     lists:filtermap(fun({Kind, Ln, Doc}) ->
         case {Extractor:code_blocks(Doc), Kind} of
             {{ok, CodeBlocks}, {doc, {M, F, A}, Tag}} ->
                 case should_test_doc({M, F, A}, Opts) of
                     true ->
-                        {true, {Ln, doctest_eunit:doc_tests({M, F, A}, Bindings, Ln, CodeBlocks, Tag)}};
+                        {true, {Ln, doctest_eunit:doc_tests({M, F, A}, Bindings, Records, Ln, CodeBlocks, Tag)}};
                     false ->
                         false
                 end;
             {{ok, CodeBlocks}, {moduledoc, M, Tag}} ->
                 case should_test_moduledoc(Opts) of
                     true ->
-                        {true, {Ln, doctest_eunit:moduledoc_tests(M, Bindings, Ln, CodeBlocks, Tag)}};
+                        {true, {Ln, doctest_eunit:moduledoc_tests(M, Bindings, Records, Ln, CodeBlocks, Tag)}};
                     false ->
                         false
                 end;

--- a/test/doctest_extract_attr_SUITE.erl
+++ b/test/doctest_extract_attr_SUITE.erl
@@ -33,13 +33,20 @@ true
 ```
 """.
 
+-record(foo, {foo}).
+-record(foobar, {foo, bar}).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
 doctest_test() ->
     doctest:module(?MODULE, #{
+        extractors => [doctest_extract_attr],
         bindings => #{'M' => ?MODULE},
-        extractors => [doctest_extract_attr]
+        records => [
+            {foo, record_info(fields, foo)},
+            {foobar, record_info(fields, foobar)}
+        ]
     }).
 -endif.
 
@@ -124,4 +131,17 @@ ok
 """.
 shell_format_test() ->
     ok.
+
+-doc """
+```
+> Foo0 = #foo{}.
+> Foo = Foo0#foo{foo = foo}.
+> Foobar = #foobar{foo = foo, bar = bar}.
+#foobar{foo = foo, bar = bar}
+> M:records_test().
+[#foo{foo = foo}, #foobar{foo = foo, bar = bar}]
+```
+""".
+records_test() ->
+    [#foo{foo = foo}, #foobar{foo = foo, bar = bar}].
 -endif.

--- a/test/doctest_extract_tag_SUITE.erl
+++ b/test/doctest_extract_tag_SUITE.erl
@@ -16,13 +16,20 @@
 -module(doctest_extract_tag_SUITE).
 -compile([export_all, nowarn_export_all]).
 
+-record(foo, {foo}).
+-record(foobar, {foo, bar}).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
 doctest_test() ->
     doctest:module(?MODULE, #{
+        extractors => [doctest_extract_tag],
         bindings => #{'M' => ?MODULE},
-        extractors => [doctest_extract_tag]
+        records => [
+            {foo, record_info(fields, foo)},
+            {foobar, record_info(fields, foobar)}
+        ]
     }).
 -endif.
 
@@ -102,3 +109,15 @@ comment_test() ->
 % '''
 shell_format_test() ->
     ok.
+
+% @doc
+% ```
+% > Foo0 = #foo{}.
+% > Foo = Foo0#foo{foo = foo}.
+% > Foobar = #foobar{foo = foo, bar = bar}.
+% #foobar{foo = foo, bar = bar}
+% > M:records_test().
+% [#foo{foo = foo}, #foobar{foo = foo, bar = bar}]
+% '''
+records_test() ->
+    [#foo{foo = foo}, #foobar{foo = foo, bar = bar}].


### PR DESCRIPTION
## Example

````erlang
-module(foo).
-record(foo, {foo}).
-record(foobar, {foo, bar}).

-ifdef(TEST).
-include_lib("eunit/include/eunit.hrl").

doctest_test() ->
    doctest:module(?MODULE, #{
        records => [
            {foo, record_info(fields, foo)},
            {foobar, record_info(fields, foobar)}
        ]
    }).
-endif.

-doc """
```
> Foo0 = #foo{}.
> Foo = Foo0#foo{foo = foo}.
> Foobar = #foobar{foo = foo, bar = bar}.
#foobar{foo = foo, bar = bar}
> foo:records().
[#foo{foo = foo}, #foobar{foo = foo, bar = bar}]
```
""".
records() ->
    [#foo{foo = foo}, #foobar{foo = foo, bar = bar}].
````